### PR TITLE
Clone passed options where the object is modified

### DIFF
--- a/lib/collections/acl_collection.js
+++ b/lib/collections/acl_collection.js
@@ -32,8 +32,7 @@ var ACLCollection = BaseCollection.extend({
     }
   },
   create: function(data, options) {
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'create';
     options.actor = options.actor || this.actor;
     debug.trace('ACLCollection(%s).create %s actor present: %d',
@@ -43,8 +42,7 @@ var ACLCollection = BaseCollection.extend({
     return ACLCollection.__super__.create.call(this, data, options);
   },
   fetch: function(options) {
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'read';
     options.actor = options.actor || this.actor;
     debug.trace('ACLCollection(%s).fetch %s actor present: %d',
@@ -54,8 +52,7 @@ var ACLCollection = BaseCollection.extend({
     return ACLCollection.__super__.fetch.call(this, options);
   },
   destroyAll: function(options) {
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'destroy';
     options.actor = options.actor || this.actor;
     debug.trace('ACLCollection(%s).destroyAll %s actor present: %d',

--- a/lib/models/acl_model.js
+++ b/lib/models/acl_model.js
@@ -36,7 +36,7 @@ var ACLModel = BaseModel.extend({
   save: function(key, val, options) {
     var opts = {};
     if (key == null || typeof key === 'object') {
-      opts = val || {};
+      opts = _.clone(val) || {};
     } else if (options) {
       opts = _.clone(options);
     }
@@ -50,8 +50,7 @@ var ACLModel = BaseModel.extend({
    * Check access before proceeding with fetchAll
    */
   fetchAll: function(options) {
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'read';
     options.actor = options.actor ||  this.actor;
     debug.trace('ACLModel(%s).fetchAll %s actor present: %d', this.type || '',
@@ -63,8 +62,7 @@ var ACLModel = BaseModel.extend({
    * Check access before proceeding with fetch
    */
   fetch: function(options) {
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'read';
     options.actor = options.actor ||  this.actor;
     debug.trace('ACLModel(%s).fetch %s actor present: %d',
@@ -97,8 +95,7 @@ var ACLModel = BaseModel.extend({
    */
   destroy: function(options) {
     var self = this;
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'destroy';
     options.actor = options.actor || this.actor;
     debug.trace('ACLModel(%s).destroy %s actor present: %d',

--- a/lib/models/base_model.js
+++ b/lib/models/base_model.js
@@ -354,8 +354,7 @@ var BaseModel = SchemaModel.extend({
    */
   fetchAll: function(options) {
     debug.trace('fetchAll %s',JSON.stringify(options));
-    // FIXME: avoid modifying the passed options
-    options = options || {};
+    options = _.clone(options) || {};
     options.action = 'read';
     var self = this;
     var when = Promises.when;


### PR DESCRIPTION
Refactor the tests that checked the problematic behavior of modifying
the passed option object. Instead, the tests check options as
passed down to sync.

Resolves #15.