### PR TITLE
BaseModel: don't use isNew as 'no id'

### DIFF
--- a/lib/models/base_model.js
+++ b/lib/models/base_model.js
@@ -108,7 +108,7 @@ var BaseModel = SchemaModel.extend({
    */
   url: function() {
     var key = this.dbBaseKey || this.type;
-    if (this.isNew()) {
+    if (!this.has(this.idAttribute)) {
       return key;
     }
     return key + ':' + this.get(this.idAttribute);


### PR DESCRIPTION
isNew method is currently implemented this way, so the implementation
of url() uses it to check if the id attribute is present. The url needs
just the id, so any overrides of isNew may corrupt the desired result.