### PR TITLE
IndexMixin: set fetchStatus property to 'fetched' when fetch completes

### DIFF
--- a/lib/collections/index_mixin.js
+++ b/lib/collections/index_mixin.js
@@ -39,7 +39,11 @@ var IndexMixin = _.extend({}, IndexedCollectionMixin, {
     if (!options.skipModelsFetch) {
       fns.push(_.bind(this.modelsFetch, this, options));
     }
-    return sequence(fns);
+    return sequence(fns)
+      .with(this)
+      .then(function() {
+        this.fetchStatus = 'fetched';
+      });
   },
 
   // deprecated


### PR DESCRIPTION
The implementation of `fetch` does not call into `BaseCollection`'s,
so at least the status has to be updated the same way to actually
prevent re-fetching in repeated calls of `applyToAll` etc.